### PR TITLE
Remove redundant setting of mode-name

### DIFF
--- a/alda-mode.el
+++ b/alda-mode.el
@@ -118,8 +118,7 @@ Because alda runs in the background, the only way to do this is with alda restar
   (setq indent-line-function 'asm-indent-line)
 
   ;; Set alda highlighting
-  (setq font-lock-defaults '(alda-highlights))
-  (setq mode-name "Alda"))
+  (setq font-lock-defaults '(alda-highlights)))
 
 ;; Open alda files in alda-mode
 ;;;###autoload


### PR DESCRIPTION
`define-derived-mode` does this for you -- try running `macroexpand-last-sexp` to see the code that macro generates.

In connection with https://github.com/milkypostman/melpa/pull/3567
