### PR TITLE
Fix bugs win10

### DIFF
--- a/alda-mode.el
+++ b/alda-mode.el
@@ -92,7 +92,8 @@ Argument CMD the cmd to run alda with"
 (defun alda-play-text (text)
   "Plays the specified TEXT in the alda server.
 ARGUMENT TEXT The text to play with the current alda server."
-  (alda-run-cmd (concat "play --code \"" text "\"")))
+  (let ((one-liner-text (replace-regexp-in-string "\n" " " text)))
+    (alda-run-cmd (concat "play --code \"" one-liner-text "\""))))
 
 (defun alda-play-file ()
   "Plays the current buffer's file in alda."

--- a/alda-mode.el
+++ b/alda-mode.el
@@ -92,8 +92,10 @@ Argument CMD the cmd to run alda with"
 (defun alda-play-text (text)
   "Plays the specified TEXT in the alda server.
 ARGUMENT TEXT The text to play with the current alda server."
-  (let ((one-liner-text (replace-regexp-in-string "\n" " " text)))
-    (alda-run-cmd (concat "play --code \"" one-liner-text "\""))))
+  (if (eql system-type 'windows-nt) 
+      (let ((one-liner-text (replace-regexp-in-string "\n" " " text)))
+        (alda-run-cmd (concat "play --code \"" one-liner-text "\"")))
+    (alda-run-cmd (concat "play --code '" text "'"))))
 
 (defun alda-play-file ()
   "Plays the current buffer's file in alda."

--- a/alda-mode.el
+++ b/alda-mode.el
@@ -92,7 +92,7 @@ Argument CMD the cmd to run alda with"
 (defun alda-play-text (text)
   "Plays the specified TEXT in the alda server.
 ARGUMENT TEXT The text to play with the current alda server."
-  (alda-run-cmd (concat "play --code '" text "'")))
+  (alda-run-cmd (concat "play --code \"" text "\"")))
 
 (defun alda-play-file ()
   "Plays the current buffer's file in alda."


### PR DESCRIPTION
I tried alda-mode on system below.

OS: Windows 10
Emacs: 25.1
Alda: 1.0.0-rc56

I found two problems.
1. It makes no sound, when I execute alda-play-region etc.

I fixed the problem with  revision 4037ac7701e72c2c361d7d88a6e94f664e00a28e.

Then I found second problem.
2. It is played only first line, even though the selected region is multi-line.

For example, when I selected 3 lines below and execute alda-play-region,
I heard the sound of trumpet only.

trumpet:  o4 c8 d e f g a b > %last-note c4.~2
trombone: o3 e8 f g a b > c d e4.~2
tuba: @last-note o2 c4.~2

I fixed the problem with  revision  ee9a723000111cdd3e6254a28219f7bf16e31af8.